### PR TITLE
[MUSA][Diffusion][13/N]  LayerNorm/RMSNorm/MulAdd  MUSA implementation

### DIFF
--- a/python/sglang/multimodal_gen/runtime/platforms/musa.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/musa.py
@@ -18,6 +18,7 @@ import torchada  # noqa: F401
 # isort: on
 from typing_extensions import ParamSpec
 
+from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.runtime.platforms.interface import (
     AttentionBackendEnum,
     DeviceCapability,
@@ -69,6 +70,10 @@ class MusaPlatformBase(Platform):
     device_type: str = "musa"
     dispatch_key: str = "MUSA"
     device_control_env_var: str = "MUSA_VISIBLE_DEVICES"
+
+    @classmethod
+    def get_local_torch_device(cls) -> torch.device:
+        return torch.device(f"musa:{envs.LOCAL_RANK}")
 
     @classmethod
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR is the 9th in a series of pull requests (tracked in https://github.com/sgl-project/sglang/issues/16565) to add full support for [Moore Threads](https://en.mthreads.com/) GPUs, leveraging MUSA (Meta-computing Unified System Architecture) to accelerate LLM inference.

## Modifications
1. Implement `LayerNorm/RMSNorm/MulAdd` `forward_musa` dispatch for MUSA cutom ops
2. Non-blocking for `fuse_scale_shift_kernel` in `runtime/layers/triton_ops.py`
3. Add `torch.profile` support for MUSA
4. Add `get_local_torch_device` func for MUSA platform

## Testing Done
Performance before modifications on MUSA
```[02-11 11:47:10] Loaded vae: AutoencoderKLWan (sgl-diffusion version). model size: 0.27 GB, avail mem: 77.84 GB
[02-11 11:47:10] Loading transformer from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/transformer. avail mem: 77.84 GB
[02-11 11:47:10] Loading WanTransformer3DModel from 2 safetensors files, default_dtype: torch.bfloat16
[02-11 11:47:10] Using Torch SDPA backend.
Loading required modules:  40%|████████████████████████████████████████████████████████████████                                                                                                | 2/5 [00:48<01:00, 20.17s/it][02-11 11:47:26] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 7.23s, 748.8 MiB/s
[02-11 11:47:27] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 16.26s, 332.8 MiB/s
[02-11 11:47:27] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 14.55s, 372.1 MiB/s
[02-11 11:47:27] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 17.7s, 305.8 MiB/s
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [01:03<00:00, 12.66s/it]
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [01:04<00:00, 12.80s/it]
[02-11 11:47:34] Loaded model with 1.42B parameters
[02-11 11:47:34] Loaded transformer: WanTransformer3DModel (sgl-diffusion version). model size: 2.64 GB, avail mem: 74.96 GB
Loading required modules:  80%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████                                | 4/5 [01:04<00:13, 13.70s/it][02-11 11:47:34] Loading scheduler from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/scheduler. avail mem: 74.96 GB
[02-11 11:47:34] Loaded scheduler: UniPCMultistepScheduler (sgl-diffusion version). model size: 0.00 GB, avail mem: 74.96 GB
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [01:04<00:00, 12.83s/it]
[02-11 11:47:34] Creating pipeline stages...
[02-11 11:47:34] Using Torch SDPA backend.
[02-11 11:47:34] Pipeline instantiated
[02-11 11:47:34] Enabled layerwise offload for WanTransformer3DModel on modules: ['blocks']
[02-11 11:47:34] Worker 0: Initialized device, model, and distributed environment.
[02-11 11:47:34] Worker 0: Scheduler loop started.
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [01:04<00:00, 12.85s/it]
[02-11 11:47:34] Diffusers version: 0.33.0.dev0
[02-11 11:47:34] Using native sglang backend for model '/data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers'
[02-11 11:47:34] Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.WanT2V_1_3B_SamplingParams'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.WanT2V480PConfig'>)
[02-11 11:47:34] Adjusting number of frames from 81 to 93 based on number of GPUs (4)
[02-11 11:47:34] Processing prompt 1/1: A curious raccoon peers through a vibrant field of yellow sunflowers, its eyes wide with interest.
[02-11 11:47:34] Sampling params:
                       width: 832
                      height: 480
                  num_frames: 93
                      prompt: A curious raccoon peers through a vibrant field of yellow sunflowers, its eyes wide with interest.
                  neg_prompt: Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards
                        seed: 42
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 3.0
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: 3.0
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_curious_raccoon_peers_through_a_vibrant_field_of_yellow_sunflowers_its_eyes_wide_with_interest._20260211-114734_fc730e86.mp4
        
[02-11 11:47:34] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[02-11 11:47:34] [InputValidationStage] started...
[02-11 11:47:34] [InputValidationStage] finished in 0.0001 seconds
[02-11 11:47:34] [TextEncodingStage] started...
[02-11 11:47:54] [TextEncodingStage] finished in 19.7699 seconds
[02-11 11:47:54] [ConditioningStage] started...
[02-11 11:47:54] [ConditioningStage] finished in 0.0000 seconds
[02-11 11:47:54] [TimestepPreparationStage] started...
[02-11 11:47:54] [TimestepPreparationStage] finished in 0.0006 seconds
[02-11 11:47:54] [LatentPreparationStage] started...
[02-11 11:47:54] [LatentPreparationStage] finished in 0.0047 seconds
[02-11 11:47:54] [DenoisingStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:16<00:00,  1.53s/it]
[02-11 11:49:10] [DenoisingStage] average time per step: 1.5347 seconds
[02-11 11:49:11] [DenoisingStage] finished in 76.8520 seconds
[02-11 11:49:11] [DecodingStage] started...
[02-11 11:49:18] [DecodingStage] finished in 7.7057 seconds
[02-11 11:49:18] Peak GPU memory: 11.80 GB, Remaining GPU memory at peak: 68.20 GB. Components that could stay resident (based on the last request workload): ['text_encoder', 'vae', 'transformer']. Related offload server args to disable: --dit-layerwise-offload, --text-encoder-cpu-offload, --vae-cpu-offload
[02-11 11:49:24] Output saved to outputs/A_curious_raccoon_peers_through_a_vibrant_field_of_yellow_sunflowers_its_eyes_wide_with_interest._20260211-114734_fc730e86.mp4
[02-11 11:49:24] Pixel data generated successfully in 109.58 seconds
[02-11 11:49:24] Completed batch processing. Generated 1 outputs in 109.58 seconds
[02-11 11:49:24] Memory usage - Max peak: 12085.11 MB, Avg peak: 12085.11 MB
```
Performance after
```[02-11 18:09:57] Loaded vae: AutoencoderKLWan (sgl-diffusion version). model size: 0.27 GB, avail mem: 77.81 GB
[02-11 18:09:57] Loading transformer from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/transformer. avail mem: 77.81 GB
[02-11 18:09:57] Loading WanTransformer3DModel from 2 safetensors files, default_dtype: torch.bfloat16
[02-11 18:09:57] Using Torch SDPA backend.
[02-11 18:10:05] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 13.89s, 389.8 MiB/s
[02-11 18:10:05] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 13.42s, 403.3 MiB/s
[02-11 18:10:05] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 12.94s, 418.5 MiB/s
[02-11 18:10:05] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 8.27s, 654.4 MiB/s
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:59<00:00, 11.98s/it]
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:59<00:00, 11.98s/it]
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [01:00<00:00, 12.01s/it]
[02-11 18:10:12] Loaded model with 1.42B parameters
[02-11 18:10:12] Loaded transformer: WanTransformer3DModel (sgl-diffusion version). model size: 2.64 GB, avail mem: 74.99 GB
Loading required modules:  80%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████                                | 4/5 [01:00<00:11, 11.71s/it][02-11 18:10:12] Loading scheduler from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/scheduler. avail mem: 74.99 GB
[02-11 18:10:12] Loaded scheduler: UniPCMultistepScheduler (sgl-diffusion version). model size: 0.00 GB, avail mem: 74.99 GB
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [01:00<00:00, 12.01s/it]
[02-11 18:10:12] Creating pipeline stages...
[02-11 18:10:12] Using Torch SDPA backend.
[02-11 18:10:12] Pipeline instantiated
[02-11 18:10:12] Enabled layerwise offload for WanTransformer3DModel on modules: ['blocks']
[02-11 18:10:12] Worker 0: Initialized device, model, and distributed environment.
[02-11 18:10:12] Worker 0: Scheduler loop started.
[02-11 18:10:12] Diffusers version: 0.33.0.dev0
[02-11 18:10:12] Using native sglang backend for model '/data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers'
[02-11 18:10:12] Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.WanT2V_1_3B_SamplingParams'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.WanT2V480PConfig'>)
[02-11 18:10:12] Adjusting number of frames from 81 to 93 based on number of GPUs (4)
[02-11 18:10:12] Processing prompt 1/1: A curious raccoon peers through a vibrant field of yellow sunflowers, its eyes wide with interest.
[02-11 18:10:12] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[02-11 18:10:12] [InputValidationStage] started...
[02-11 18:10:12] [InputValidationStage] finished in 0.0001 seconds
[02-11 18:10:12] [TextEncodingStage] started...
[02-11 18:10:32] [TextEncodingStage] finished in 19.3525 seconds
[02-11 18:10:32] [ConditioningStage] started...
[02-11 18:10:32] [ConditioningStage] finished in 0.0000 seconds
[02-11 18:10:32] [TimestepPreparationStage] started...
[02-11 18:10:32] [TimestepPreparationStage] finished in 0.0007 seconds
[02-11 18:10:32] [LatentPreparationStage] started...
[02-11 18:10:32] [LatentPreparationStage] finished in 0.0047 seconds
[02-11 18:10:32] [DenoisingStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:56<00:00,  1.13s/it]
[02-11 18:11:28] [DenoisingStage] average time per step: 1.1282 seconds
[02-11 18:11:28] [DenoisingStage] finished in 56.6974 seconds
[02-11 18:11:28] [DecodingStage] started...
[02-11 18:11:31] [DecodingStage] finished in 2.8870 seconds
[02-11 18:11:31] Peak GPU memory: 10.50 GB, Remaining GPU memory at peak: 69.50 GB. Components that could stay resident (based on the last request workload): ['text_encoder', 'vae', 'transformer']. Related offload server args to disable: --dit-layerwise-offload, --text-encoder-cpu-offload, --vae-cpu-offload
[02-11 18:11:32] Output saved to outputs/A_curious_raccoon_peers_through_a_vibrant_field_of_yellow_sunflowers_its_eyes_wide_with_interest._20260211-181012_3dffdcf5.mp4
[02-11 18:11:32] Pixel data generated successfully in 79.87 seconds
[02-11 18:11:32] Completed batch processing. Generated 1 outputs in 79.87 seconds
[02-11 18:11:32] Memory usage - Max peak: 10756.54 MB, Avg peak: 10756.54 MB
```
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
7. After green CI and required approvals, ask Merge Oncalls to merge.
